### PR TITLE
Don't add same user to ignore list more than once

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ imgur.on('comment', function (comment) {
 setInterval(function () {
     reddit.getUnreadMessages().then((list) => {
         list.forEach(function (item) {
-            if (item.body.startsWith("ignoreme")) {
+            if (item.body.startsWith("ignoreme") && ignore.indexOf(item.author.name) == -1) {
                 fs.appendFile("ignore", item.author.name+"\n", function () { });
                 ignore.push(item.author.name);
                 item.markAsRead();


### PR DESCRIPTION
This adds a check to see if the user is already in the ignore list before adding them. It  avoids adding the same user more than once.